### PR TITLE
Fix import in to_pyomo()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-src/FoKL/__pycache__/
+src/FoKL/__pycache__/*
 .idea
 .spyder*
 .ropeproject

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
 src/FoKL/__pycache__/
+.idea
+.spyder*
+.ropeproject
+.vscode
+*.pyx
+*.pyc
+*.pyo
+*.egg-info
+*.out
+.ipynb_checkpoints
+*.DS_Store*

--- a/src/FoKL/FoKLRoutines.py
+++ b/src/FoKL/FoKLRoutines.py
@@ -1801,7 +1801,12 @@ class FoKL:
             raise ImportError(
                 "Pyomo must be installed to use this method. try pip install FoKL[pyomo] or pip install pyomo directly"
             )
-        from src.FoKL.fokl_to_pyomo import fokl_to_pyomo
+        try:
+            # Look for a local version of FoKL in a standard place
+            from src.FoKL.fokl_to_pyomo import fokl_to_pyomo
+        except ModuleNotFoundError:
+            # Try to import from the installed package
+            from FoKL.fokl_to_pyomo import fokl_to_pyomo
         return fokl_to_pyomo(self, xvars, yvars, m, xfix, yfix, truescale, std, draws)
 
     def save(self, filename=None, directory=None):


### PR DESCRIPTION
An import was looking in ``./src`` for FoKL.  This fixes it to also find installed packages if FoKL is not in ``src``.  I also tried to fix .gitignore.  Commit all was picking up ``.pyc`` files.